### PR TITLE
fix(gatsby-telemetry): add event-storage.js to files

### DIFF
--- a/packages/gatsby-telemetry/package.json
+++ b/packages/gatsby-telemetry/package.json
@@ -38,7 +38,8 @@
   "files": [
     "lib",
     "src/postinstall.js",
-    "src/showAnalyticsNotification.js"
+    "src/showAnalyticsNotification.js",
+    "src/event-storage.js"
   ],
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-telemetry#readme",
   "keywords": [


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

Fix

```plain
Error: Cannot find module './event-storage.js'
```

## Related Issues

Fix #16293